### PR TITLE
Output team names for use in composite action

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -28072,14 +28072,16 @@ async function main() {
     console.log(rateLimitData);
     const requiredApprovals = outstandingCodeownerRequests.length === 0;
     let reason;
+    let teams = "";
     if (requiredApprovals) {
       reason = "all codeowners have provided reviews";
     } else {
-      reason = `codeowners ${outstandingCodeownerRequests.join(", ")} have not provided reviews`;
+      teams = outstandingCodeownerRequests.join(", ");
+      reason = `codeowners ${teams} have not provided reviews`;
     }
 
     const outputPath = src_process.env["GITHUB_OUTPUT"];
-    fs.appendFileSync(outputPath, `approved=${requiredApprovals.toString().toLowerCase()}`);
+    fs.appendFileSync(outputPath, `teams=${teams}`);
 
     if (requiredApprovals) {
         console.info(`Required approvals met: ${reason}`);

--- a/result
+++ b/result
@@ -1,1 +1,1 @@
-approved=true
+teams=sms

--- a/src/index.js
+++ b/src/index.js
@@ -273,14 +273,16 @@ async function main() {
     console.log(rateLimitData);
     const requiredApprovals = outstandingCodeownerRequests.length === 0;
     let reason;
+    let teams = "";
     if (requiredApprovals) {
       reason = "all codeowners have provided reviews";
     } else {
-      reason = `codeowners ${outstandingCodeownerRequests.join(", ")} have not provided reviews`;
+      teams = outstandingCodeownerRequests.join(", ");
+      reason = `codeowners ${teams} have not provided reviews`;
     }
 
     const outputPath = process.env["GITHUB_OUTPUT"];
-    fs.appendFileSync(outputPath, `approved=${requiredApprovals.toString().toLowerCase()}`);
+    fs.appendFileSync(outputPath, `teams=${teams}`);
 
     if (requiredApprovals) {
         console.info(`Required approvals met: ${reason}`);


### PR DESCRIPTION
We're using `steps.check_approvals.outcome` in the main workflow, so we don't actually need the `approved=true` output

I'd like to log require teams instead, so that we can add it to the workflow status message for convenience https://github.com/Appboy/platform/blob/444c95b20ef1d6c91026ffd14617c649d2d19e7a/.github/workflows/require_codeowner_reviews.yml#L78