### PR TITLE
Fix pattern matching for "/dashboard/patches/@tiptap*"

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -24152,8 +24152,7 @@ function getCodeowners(codeownersFile, changedFiles) {
         continue;
       }
 
-      const pattern = line.trim().match(/^[^@]+/)[0].trim();
-      const owners = line.trim().match(/@\S+/g);
+      let [pattern, ...owners] = line.trim().split(/(?<!\\)\s+/);
       if (!pattern) {
         continue;
       }

--- a/src/getCodeowners.js
+++ b/src/getCodeowners.js
@@ -17,8 +17,7 @@ function getCodeowners(codeownersFile, changedFiles) {
         continue;
       }
 
-      const pattern = line.trim().match(/^[^@]+/)[0].trim();
-      const owners = line.trim().match(/@\S+/g);
+      let [pattern, ...owners] = line.trim().split(/(?<!\\)\s+/);
       if (!pattern) {
         continue;
       }

--- a/test/codeowners.txt
+++ b/test/codeowners.txt
@@ -9,3 +9,5 @@
 /containers/dashboard/ @Appboy/monolith-foundations
 /containers/dashboard/Dockerfile.test.frontend @Appboy/frontend-ix
 /containers/dashboard/Docker\ Thing.test @Appboy/frontend-ix
+/dashboard/patches @Appboy/frontend-ix
+/dashboard/patches/@tiptap* @Appboy/composition-infrastructure

--- a/test/getCodeowners.js
+++ b/test/getCodeowners.js
@@ -70,4 +70,18 @@ test('getCodeowners', { concurrency: true }, (t) => {
     ]);
     assert.deepStrictEqual(codeowners, ["frontend-ix"]);
   });
+
+  t.test("changes to files with @ in the name", () => {
+    const codeowners = getCodeowners(codeownersData, [
+      "/dashboard/patches/@tiptap-123",
+    ]);
+    assert.deepStrictEqual(codeowners, ["composition-infrastructure"]);
+  });
+
+  t.test("changes to files similar to a rule with @ in the name", () => {
+    const codeowners = getCodeowners(codeownersData, [
+      "/dashboard/patches/another-file",
+    ]);
+    assert.deepStrictEqual(codeowners, ["frontend-ix"]);
+  });
 });


### PR DESCRIPTION
/dashboard/patches/@tiptap* was being matched to pattern=/dashboard/patches and owners=tiptap, which is not correct (see https://github.com/Appboy/platform/actions/runs/18295778748/job/52093742374)

This reverts the change made in https://github.com/braze-inc/required-approvals/pull/11, and instead changes the original `line.trim().split(/\s+/);` to be `line.trim().split(/(?<!\\)\s+/);` i.e. split on whitespace, EXCEPT whitespace preceded by a `\`